### PR TITLE
Source path should be https:// and not git://

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "version": "dev-master",
   "source": {
-    "url": "git://github.com//emarchak/fastpaced_videos.git",
+    "url": "https://github.com//emarchak/fastpaced_videos.git",
     "type": "git",
     "reference": "master"
   }


### PR DESCRIPTION
I believe the source path should be https:// and not git:// unless you want to add 

`"secure-http": false` to the config section as the latest version of composer will throw a nasty error otherwise

```
 [Composer\Downloader\TransportException]
  Your configuration does not allow connections to git://github.com/[username]/[repo].git. See https://getcomposer.org/doc/06-
  config.md#secure-http for details.
```
